### PR TITLE
Update regex to consider js and stylesheet conditionals

### DIFF
--- a/app/code/community/Meanbee/Footerjs/Model/Observer.php
+++ b/app/code/community/Meanbee/Footerjs/Model/Observer.php
@@ -3,7 +3,7 @@ class Meanbee_Footerjs_Model_Observer {
 
     // Regular expression that matches one or more script tags (including conditions or comments)
     const REGEX_JS  = '#(\s*<![^>]*>\s*(\s*<script.*</script>)+\s*<![^>]*-->)|(\s*<script.*</script>)#isU';
-    const REGEX_DOCUMENT_END    = '#</body>.*</html>#isU';
+    const REGEX_DOCUMENT_END    = '#</body>\s*</html>#isU';
 
     /**
      * @param Varien_Event_Observer $observer

--- a/app/code/community/Meanbee/Footerjs/Model/Observer.php
+++ b/app/code/community/Meanbee/Footerjs/Model/Observer.php
@@ -2,7 +2,7 @@
 class Meanbee_Footerjs_Model_Observer {
 
     // Regular expression that matches one or more script tags (including conditions or comments)
-    const REGEX_JS  = '#(\s*<![^>]*>\s*(\s*<script.*</script>)+\s*<![^>]*-->)|(\s*<script.*</script>)#isU';
+    const REGEX_JS  = '#(\s*<![^>]*>\s*(<script.*</script>)+\s*<![^>]*-->)|(\s*<script.*</script>)#isU';
     const REGEX_DOCUMENT_END    = '#</body>\s*</html>#isU';
 
     /**


### PR DESCRIPTION
Stylesheet conditionals were breaking the matches e.g. 

`<!--[if  (IE 9) & (!IEMobile)]>
    <link rel="stylesheet" type="text/css" href="" media="all" />
<![endif]-->`

I've also changed the regex for the document end to be more explicit so that it only matches html and does not match in other edge cases such as body and html closing tags built in js through concatenation.
