### PR TITLE
Add black list for blocks to don't move JS from them to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Tested against:
 
 Enable the extension in `System > Configuration > Advanced > Developer > JavaScript Settings > Move JavaScript to Footer`.
 
-Add block names with JS which must not be moved to footer in `System > Configuration > Advanced > Developer > JavaScript Settings > FooterJS Excluded Blocks`.
-Enter block names separated with Comma. Please note, JS libraries are moved to footer so be carefull with excluding JS which requires that libraries.
+Add name of blocks with JS which must not be moved to footer in `System > Configuration > Advanced > Developer > JavaScript Settings > FooterJS Excluded Blocks`.
+Enter block names separated with a comma. Please note, JS libraries are moved to footer so be careful excluding JS which has dependencies.
 
-Also there is another way to exclude some JS from moving to the footer - add attribute `data-meanbee-skip="true"` to `script` tag.
+Also there is another way to exclude some JS from moving to the footer - add attribute `data-footer-js-skip="true"` to `script` tag.
 Currently there is no way to exclude JS added using addJs/addItem in layout.
 
 # License

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ Tested against:
 
 - CE 1.9
 - EE 1.14 (inc FPC)
- 
+
 # Usage
 
 Enable the extension in `System > Configuration > Advanced > Developer > JavaScript Settings > Move JavaScript to Footer`.
+
+Add block names with JS which must not be moved to footer in `System > Configuration > Advanced > Developer > JavaScript Settings > FooterJS Excluded Blocks`.
+Enter block names separated with Comma. Please note, JS libraries are moved to footer so be carefull with excluding JS which requires that libraries.
+
+Also there is another way to exclude some JS from moving to the footer - add attribute `data-meanbee-skip="true"` to `script` tag.
+Currently there is no way to exclude JS added using addJs/addItem in layout.
 
 # License
 

--- a/app/code/community/Meanbee/Footerjs/Helper/Data.php
+++ b/app/code/community/Meanbee/Footerjs/Helper/Data.php
@@ -9,8 +9,8 @@ class Meanbee_Footerjs_Helper_Data extends Mage_Core_Helper_Abstract {
     const XML_CONFIG_FOOTERJS_ENABLED = 'dev/js/meanbee_footer_js_enabled';
     const XML_CONFIG_FOOTERJS_EXCLUDED_BLOCKS = 'dev/js/meanbee_footer_js_excluded_blocks';
 
-    const EXCLUDE_FLAG = 'data-meanbee-skip="true"';
-    const EXCLUDE_FLAG_PATTERN = 'data-meanbee-skip';
+    const EXCLUDE_FLAG = 'data-footer-js-skip="true"';
+    const EXCLUDE_FLAG_PATTERN = 'data-footer-js-skip';
 
     /** @var array */
     protected $_blocksToExclude;

--- a/app/code/community/Meanbee/Footerjs/Model/Observer.php
+++ b/app/code/community/Meanbee/Footerjs/Model/Observer.php
@@ -14,6 +14,7 @@ class Meanbee_Footerjs_Model_Observer {
         /** @var Meanbee_Footerjs_Helper_Data $helper */
         $helper = Mage::helper('meanbee_footerjs');
         if (!$helper->isEnabled()) {
+            Varien_Profiler::stop('MeanbeeFooterJs');
             return $this;
         }
 
@@ -38,6 +39,7 @@ class Meanbee_Footerjs_Model_Observer {
         /** @var Meanbee_Footerjs_Helper_Data $helper */
         $helper = Mage::helper('meanbee_footerjs');
         if (!$helper->isEnabled()) {
+            Varien_Profiler::stop('MeanbeeFooterJs');
             return $this;
         }
 
@@ -47,12 +49,18 @@ class Meanbee_Footerjs_Model_Observer {
         /** @var Mage_Core_Block_Abstract $block */
         $block = $observer->getBlock();
 
+        if (in_array($block->getNameInLayout(), $helper->getBlocksToSkipMoveJs())) {
+            $transport->setHtml($helper->addJsToExclusion($transport->getHtml()));
+        }
+
         if (Mage::app()->getRequest()->getModuleName() == 'pagecache') {
             $transport->setHtml($helper->removeJs($transport->getHtml()));
+            Varien_Profiler::stop('MeanbeeFooterJs');
             return $this;
         }
 
         if (!is_null($block->getParentBlock())) {
+            Varien_Profiler::stop('MeanbeeFooterJs');
             // Only look for JS at the root block
             return $this;
         }

--- a/app/code/community/Meanbee/Footerjs/Model/PageCache/Observer.php
+++ b/app/code/community/Meanbee/Footerjs/Model/PageCache/Observer.php
@@ -24,6 +24,10 @@ class Meanbee_Footerjs_Model_PageCache_Observer extends Enterprise_PageCache_Mod
 
         if ($transport && $placeholder && !$block->getSkipRenderTag()) {
             $blockHtml = $transport->getHtml();
+            $footerJs = Mage::helper('meanbee_footerjs');
+            if (in_array($block->getNameInLayout(), $footerJs->getBlocksToSkipMoveJs())) {
+                $blockHtml = $footerJs->addJsToExclusion($blockHtml);
+            }
 
             $request = Mage::app()->getFrontController()->getRequest();
             /** @var $processor Enterprise_PageCache_Model_Processor_Default */
@@ -36,7 +40,6 @@ class Meanbee_Footerjs_Model_PageCache_Observer extends Enterprise_PageCache_Mod
                     $container->setPlaceholderBlock($block);
 
                     // Modify to not save block with JS in it as JS is being moved to the end of the page.
-                    $footerJs = Mage::helper('meanbee_footerjs');
                     $container->saveCache($footerJs->removeJs($blockHtml));
                 }
             }

--- a/app/code/community/Meanbee/Footerjs/etc/system.xml
+++ b/app/code/community/Meanbee/Footerjs/etc/system.xml
@@ -17,7 +17,7 @@
                         <meanbee_footer_js_excluded_blocks translate="label comment">
                             <label>FooterJS Excluded Blocks</label>
                             <frontend_type>textarea</frontend_type>
-                            <comment><![CDATA[Block names in layout, separated with Comma. All JS from these blocks will stay untouched and will not be moved to footer.<br/><strong>Warning:</strong> JS libraries are moved to footer so be carefull with excluding JS which requires that libraries.]]></comment>
+                            <comment><![CDATA[Enter block names separated with a comma. All JS from these blocks will stay untouched and will not be moved to footer.<br/><strong>Warning:</strong> JS libraries are moved to footer, so please be careful when you are excluding JS, which has dependencies.]]></comment>
                             <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>

--- a/app/code/community/Meanbee/Footerjs/etc/system.xml
+++ b/app/code/community/Meanbee/Footerjs/etc/system.xml
@@ -14,6 +14,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </meanbee_footer_js_enabled>
+                        <meanbee_footer_js_excluded_blocks translate="label comment">
+                            <label>FooterJS Excluded Blocks</label>
+                            <frontend_type>textarea</frontend_type>
+                            <comment><![CDATA[Block names in layout, separated with Comma. All JS from these blocks will stay untouched and will not be moved to footer.<br/><strong>Warning:</strong> JS libraries are moved to footer so be carefull with excluding JS which requires that libraries.]]></comment>
+                            <sort_order>30</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </meanbee_footer_js_excluded_blocks>
                     </fields>
                 </js>
             </groups>


### PR DESCRIPTION
Main idea is to have list of blocks (by name in layout) which will be excluded from moving their JS to footer. This achived by adding data flag to script tag (thanks @toddbc for idea) for all JS in blocks from black list and then excluding all JS with that flag from moving to the footer. 
So some JS can be excluded from moving to footer:
1. by adding its block name to `System > Configuration > Advanced > Developer > JavaScript Settings > FooterJS Excluded Blocks`
2. by adding `data-meanbee-skip="true"` to script tag (nee to modify template)
